### PR TITLE
Remove separator in column titles, add cli arguments

### DIFF
--- a/pcap_bw.py
+++ b/pcap_bw.py
@@ -52,11 +52,11 @@ if __name__ == '__main__':
         hostbw = { i: { j: 0 for j in HOSTS } for i in HOSTS }
         for ts, hdr, buf in pcap:
             if prevts == 0:
-                s = ", ".join(
+                s = ",".join(
                     ",".join([":".join([s,d]) for d in HOSTS])
                     for s in HOSTS
                 )
-                print("# time, totalbw, %s" % s, sep=",", flush=True)
+                print("# time,totalbw,%s" % s, sep=",", flush=True)
             cnt += 1
             if cnt % 10000 == 0:
                 print(cnt, "...", end="", sep="", flush=True, file=sys.stderr)


### PR DESCRIPTION
The original column titles ended up as:
```
['# time', '  totalbw', ' 10.0.0.1:10.0.0.1', '10.0.0.1:10.0.0.2', ... ' 10.0.0.2:10.0.0.1'...]
```
With the leading space. That has been removed in the first commit.

The second commit adds command line arguments for the input file, host names and window size (it can also now accept no hosts if just the total is needed). 